### PR TITLE
Bug fixes; fix disk reads; enter protected mode; Makefile update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.img
 *.bin
+*.elf
 *.o

--- a/linker.ld
+++ b/linker.ld
@@ -1,16 +1,19 @@
-OUTPUT_FORMAT("binary")
 ENTRY(main)
 
 SECTIONS
 {
-    . = 0x7e00;
+    . = 0x8000;
 
     .text : {
-        *(.text)
+        *(.text*)
     }
 
     .data : {
         *(.data)
+    }
+
+    .rodata : {
+        *(.rodata*)
     }
 
     .bss : {

--- a/loader.asm
+++ b/loader.asm
@@ -1,15 +1,7 @@
 bits 16
-org 0x8000
+org 0x7e00
 
 start:
-    cli
-    xor ax, ax
-    mov ss, ax
-    mov sp, 0x7c00
-    mov ax, 0x8000
-    mov ds, ax
-    sti
-
     mov ah, 0x0e
     mov al, ' '
     int 0x10
@@ -23,8 +15,8 @@ start:
     mov ch, 0
     mov dh, 0
     mov cl, 3
-    mov dl, 0x80
-    mov bx, 0x7e00
+;   mov dl, 0x80              ; Use value in DL passed from mbr.asm
+    mov bx, 0x8000
     int 0x13
 
     jc read_error
@@ -37,7 +29,18 @@ start:
     mov al, 'e'
     int 0x10
 
-    jmp 0x7e00
+    ; Enter 32-bit mode (we start in 16-bit real mode)
+    cli
+    lgdt [gdt.gdtr]            ; Load our GDTR
+    mov eax, cr0
+    or eax, 0x1                ; Set protected mode (bit 0)
+    mov cr0, eax               ; Enable protected mode
+
+    jmp CODE32_PL0_SEL:pm32_enter
+                               ; Enter 32-bit protected mode. Set CS
+
+    cld                        ; Ensure string processing is forward (DF=0)
+    jmp 0x8000                 ; Jump to kernel
 
 read_error:
     mov ah, 0x0e
@@ -46,6 +49,53 @@ read_error:
     mov al, 'K'
     int 0x10
     hlt
+
+bits 32
+pm32_enter:
+    mov eax, DATA32_PL0_SEL
+    mov ds, eax
+    mov es, eax
+    mov fs, eax
+    mov gs, eax
+    mov ss, eax
+    movzx esp, sp              ; Zero extend 16-bit stack pointer to 32-bits
+
+    jmp 0x8000                 ; Jump to kernel
+
+
+; Macro to build a GDT descriptor entry
+%define MAKE_GDT_DESC(base, limit, access, flags)  \
+    dq (((base & 0x00FFFFFF) << 16) |  \
+       ((base & 0xFF000000) << 32) |  \
+       (limit & 0x0000FFFF) |      \
+       ((limit & 0x000F0000) << 32) |  \
+       ((access & 0xFF) << 40) |  \
+       ((flags & 0x0F) << 52))
+
+; GDT structure
+align 8
+gdt:
+.start:
+.null:       MAKE_GDT_DESC(0, 0, 0, 0)
+                               ; Null descriptor
+.code32_pl0: MAKE_GDT_DESC(0, 0x000FFFFF, 10011011b, 1100b)
+                               ; 32-bit code, PL0, gran=page, acc=1, r/x
+                               ; Lim=0xffffffff
+.data32_pl0: MAKE_GDT_DESC(0, 0x000FFFFF, 10010011b, 1100b)
+                               ; 32-bit data, PL0, gran=page, acc=1, r/w
+                               ; Lim=0xffffffff
+.end:
+
+; GDT record
+align 4
+    dw 0                       ; Padding align dd GDT in gdtr on 4 byte boundary
+.gdtr:
+    dw .end - .start - 1       ; limit (Size of GDT - 1)
+    dd .start                  ; base of GDT
+
+CODE32_PL0_SEL EQU gdt.code32_pl0 - gdt.start
+DATA32_PL0_SEL EQU gdt.data32_pl0 - gdt.start
+
 
 times 510 - ($ - $$) db 0
 dw 0xaa55

--- a/mbr.asm
+++ b/mbr.asm
@@ -2,6 +2,15 @@ bits 16
 org 0x7c00
 
 start:
+    ; Initialize segment registers to 0. Stack =0x0000:0x7c00 below bootloader
+    cli
+    xor ax, ax
+    mov ss, ax
+    mov sp, 0x7c00
+    sti
+    mov es, ax
+    mov ds, ax
+
     mov ah, 0x0e
     mov al, 'S'
     int 0x10
@@ -13,13 +22,13 @@ start:
     mov ch, 0
     mov dh, 0
     mov cl, 2
-    mov dl, 0x80
-    mov bx, 0x8000
+;    mov dl, 0x80              ; Use value in DL passed by BIOS to bootloader
+    mov bx, 0x7E00             ; Read to ES:BX = 0x0000:0x7E00 = 0x07e00
     int 0x13
 
     jc read_error
 
-    jmp 0x8000
+    jmp 0x7E00                 ; Jump to second stage
 
 read_error:
     mov ah, 0x0e


### PR DESCRIPTION
- `mbr.asm` (first stage) and `diskload.asm` (second stage) were reading to the wrong to places in memory
   - Read `diskload.bin` (sector 2) to 0x0000:0x7e00
   - Read `kernel.bin` (sector 3) to 0x0000:0x8000
 - Modify `mbr.asm` to initialize the segment registers and the stack SS:SP. SS:SP set to 0x0000:0x7c00 safely out of the way under the bootloader at 0x7c00.
 - Modify `mbr.asm` to use `DL` as the drive letter passed by the BIOS to our bootloader.
 - Modify `diskload.asm` to enter 32-bit protected mode before running the kernel. You can't run 32-bit code while still in real mode.
 - Modify `Makefile` to generate `kernel.elf` (for debugging) and then generate `kernel.bin` from `kernel.elf` using `objcopy`
 - Other minor fixes
