### PR TITLE
Fix issues getting into protected mode

### DIFF
--- a/mbr.asm
+++ b/mbr.asm
@@ -5,7 +5,7 @@
     ; Bootloader should set segments it intends to use to the expected
     ; value.
     ;
-    xor ax, ax
+    xor ax, ax                 ; DS=ES=SS=0
     mov ds, ax
     mov es, ax
     mov ss, ax

--- a/mbr.asm
+++ b/mbr.asm
@@ -2,6 +2,21 @@
 [org 0x7c00]
 
 .start:
+    ; Bootloader should set segments it intends to use to the expected
+    ; value.
+    ;
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7c00             ; Set initial stack (SS:SP) somehwere we know we
+                               ;     we won't write on top with a disk read like
+                               ;     placing it at 0x0000:0x7c00 grows down
+                               ;     below the bootloader and won't be
+                               ;     clobbered by by our disk reads
+
+    cld                        ; Ensure string processing is forward (DF=0)
+                               ;     for isntructions like LODS, MOVS, CMPS
     mov si, msg
     call print_string
 

--- a/protected.asm
+++ b/protected.asm
@@ -2,18 +2,18 @@ gdt_start:
     dq 0x0000000000000000
 
     dw 0xffff
-    dw 0x9000
+    dw 0x0000
     db 0x00
     db 10011010b
     db 11001111b
-    dw 0x00
+    db 0x00            ; DB, not DW. GDT entries are exactly 8 bytes in size
 
     dw 0xffff
-    dw 0x9000
+    dw 0x0000
     db 0x00
     db 10010010b
     db 11001111b
-    dw 0x00
+    db 0x00            ; DB, not DW. GDT entries are exactly 8 bytes in size
 gdt_end:
 
 gdtr:

--- a/second.asm
+++ b/second.asm
@@ -3,15 +3,12 @@
 
 start:
     cli
-    
+
     mov si, msg
     call print_string
 
     call enable_a20_fast
     call enter_protected_mode
-
-hang:
-    jmp hang
 
 print_string:
     mov ah, 0x0e
@@ -36,18 +33,23 @@ a20_e_msg db 'E:A20 ', 0
 vga_buffer equ 0xb8000
 
 protected_mode:
+    ; You need to set the protected mode selectors
+    ; once you are in protected mode
     mov ax, 0x10
     mov ds, ax
     mov es, ax
     mov fs, ax
     mov gs, ax
     mov ss, ax
-    mov esp, 0xa000
-    
-    mov si, pmode_s_msg
+    mov esp, 0xa000      ; For performance stack should be DWORD aligned
+
+    mov ah, 0x0f         ; Set bright white on black
+    mov esi, pmode_s_msg ; Need to set ESI not SI
+                         ; now that we're in 32-bit protected mode
     call print_32_string
 
-    jmp $
+hang:                    ; Move the jmp hang code into the [bits32] code
+    jmp hang
 
 print_32_string:
     mov ebx, vga_buffer


### PR DESCRIPTION
Issues getting into 32-bit protected mode and other bug fixes:

- GDT entries are exactly 8 bytes, not 9. The last `dw 0x0000` in each entry needs to be `db 0x00`.
- You must set the 32-bit selectors for `DS`, `ES`, `SS`, `FS`, and `GS` once in 32-bit protected mode and not before.
- In 32-bit protected mode the stack `ESP` should be aligned on a DWORD (4-byte boundary) for performance reasons. That means it should be evenly divisible by 4. Change 0x9FFF to 0xA000.
- When printing in 32-bit protected mode you don't set the attribute in `AH` to the actual foreground and background color you want so it will likely be black on black.
- In 32-bit protected mode you need to start using 32-bit registers for addresses. You had `mov si, pmode_s_msg` that should be `mov esi, pmode_s_msg`.
- You should move the `hang: jmp hang` into the `[bit32]` area since it will be running in 32-bit protected mode. Note: it happens to be the code in this case would run the same so it didn't cause an issue.
- To avoid potential bugs (especially on real hardware) properly initialize the segment registers to values you want (0x0 in your case); set an initial real mode stack `SS:SP` where your disk reads won't clobber it; and clear direction flag (DF=0) in `mbr.asm` since we are using instruction `LODSB`. 
- During your last commit you erroneously set the base to 0x9000 in the GDT entries rather than 0x0000.
