### PR TITLE
Ensure kmain is at start of kernel.bin, fix bugs reading to 0x10000

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GCC = $(HOME)/opt/cross/bin/i686-elf-gcc
 GCC_FLAGS = -ffreestanding -m32
 
 LD = $(HOME)/opt/cross/bin/i686-elf-ld
-LD_FLAGS = -Ttext 0x10000 -m elf_i386 --oformat binary
+LD_FLAGS = -Tlinker.ld -m elf_i386 --oformat binary
 
 QEMU = qemu-system-x86_64
 
@@ -37,7 +37,7 @@ $(KERNEL_OBJ): $(KERNEL_SRC)
 $(KERNEL_BIN): $(KERNEL_OBJ)
 	$(LD) $(LD_FLAGS) $(KERNEL_OBJ) -o $(KERNEL_BIN)
 
-$(DISK_IMG): $(MBR_BIN) $(SECOND_BIN)
+$(DISK_IMG): $(MBR_BIN) $(SECOND_BIN) $(KERNEL_BIN)
 	qemu-img create -f raw $(DISK_IMG) $(DISK_SIZE)
 
 	$(DD) if=$(MBR_BIN) of=$(DISK_IMG) bs=512 count=1 conv=notrunc

--- a/kernel.c
+++ b/kernel.c
@@ -9,7 +9,10 @@ uint16_t vga_entry(char ch, uint8_t color) {
     return (uint16_t)ch | (uint16_t)color << 8;
 }
 
-void kmain(void) {
+/* Add .text.entry before all other sections in linker script
+ * and ensure that kmain is the first code in kernel.bin
+ * at 0x10000 */
+void __attribute__((section(".text.entry"))) kmain(void) {
     vga_buffer[0] = vga_entry('A', WHITE_ON_BLACK);
 
     while (1) {}

--- a/linker.ld
+++ b/linker.ld
@@ -1,15 +1,15 @@
-OUTPUT_FORMAT(binary)
 ENTRY(kmain)
 
 SECTIONS {
     . = 0x10000;
 
     .text : {
-        *(.text)
+        *(.text.entry)
+        *(.text*)
     }
 
     .rodata : {
-        *(.rodata)
+        *(.rodata*)
     }
 
     .data : {

--- a/second.asm
+++ b/second.asm
@@ -9,7 +9,11 @@ start:
 
     call enable_a20_fast
 
-    mov bx, 0x10000
+    push 0x1000
+    pop es                     ; ES=0x1000
+    mov bx, 0x0                ; BX=0x0000
+    ; Int13h/AH=2 disk read to ES:BX. ES:BX=0x1000:0x0000
+    ; (ES<<4)+BX = (0x1000<<4)+0x0000 = phys address 0x10000
     call load_kernel
 
     call enter_protected_mode
@@ -29,7 +33,7 @@ load_kernel:
     mov ah, 0x02
     mov al, 9
     mov ch, 0
-    mov cl, 2
+    mov cl, 3
     mov dh, 0
     mov dl, 0x80
     int 0x13
@@ -68,9 +72,9 @@ protected_mode:
     mov esi, pmode_s_msg
     call print_32_string
 
-    jmp 0x08:0x10000
+    jmp 0x10000                 ; Previously set CS to 0x08
+                                ;     don't need to do it again
     
-    jmp hang
 
 print_32_string:
     mov ebx, vga_buffer


### PR DESCRIPTION
You can't put an address in a 16-bit register that is greater than 16-bits. 0x10000 doesn't fit in 16-bits. You must specify `ES:BX` of 0x1000:0000 = (0x1000<<4)+0x0000=physical address 0x10000. You must make sure you `kmain` is at the start of `kernel.bin` so it is the first code that executes when you jump to 0x10000. Modify Makefile to use the linker script `linker.ld` rather than `-Ttext=0x10000).