### PR TITLE
Fix bug where kernel address displays as 0x1

### DIFF
--- a/kernel.h
+++ b/kernel.h
@@ -8,7 +8,7 @@
 typedef struct {
     unsigned short magic;
     unsigned int kernel_address;
-} boot_info_t;
+} __attribute__((packed)) boot_info_t;
 
 extern boot_info_t *boot_info;
 


### PR DESCRIPTION
`boot_info_t` doesn't use natural alignment. Use attribute `packed` on the struct.